### PR TITLE
translations: use latest tc v55.1.1

### DIFF
--- a/builders/generic_translations_gcp.yaml
+++ b/builders/generic_translations_gcp.yaml
@@ -3,7 +3,7 @@ platform: linux
 # machine_type:  # TODO: use a larger instance for faster builds (singularity)
 
 builder_var_files:
-  - taskcluster_version_latest  # new file as non-latest still needed for d-w
+  - taskcluster_version_translations  # new file as non-latest still needed for d-w
   - default_linux
   - translations_gcp  # TODO: merge this and following?
   - googlecompute_translations

--- a/poetry.lock
+++ b/poetry.lock
@@ -164,13 +164,13 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "23.1"
+version = "23.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "packaging-23.1-py3-none-any.whl", hash = "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61"},
-    {file = "packaging-23.1.tar.gz", hash = "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"},
+    {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
+    {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
 ]
 
 [[package]]

--- a/template/vars/taskcluster_version_translations.yaml
+++ b/template/vars/taskcluster_version_translations.yaml
@@ -1,3 +1,3 @@
 # This defines the current Taskcluster version, the default version for worker-runner and workers.
 env_vars:
-  TASKCLUSTER_VERSION: 48.1.0
+  TASKCLUSTER_VERSION: 55.1.1


### PR DESCRIPTION
A newer version of the TC components is needed to allow jobs with longer expirations.