### PR TITLE
wayland images: use tc components v64

### DIFF
--- a/template/vars/taskcluster_version_firefoxci.yaml
+++ b/template/vars/taskcluster_version_firefoxci.yaml
@@ -1,3 +1,3 @@
 # This defines the current Taskcluster version, the default version for worker-runner and workers.
 env_vars:
-  TASKCLUSTER_VERSION: 60.4.2
+  TASKCLUSTER_VERSION: 62.0.0

--- a/template/vars/taskcluster_version_firefoxci.yaml
+++ b/template/vars/taskcluster_version_firefoxci.yaml
@@ -1,3 +1,3 @@
 # This defines the current Taskcluster version, the default version for worker-runner and workers.
 env_vars:
-  TASKCLUSTER_VERSION: 60.4.0
+  TASKCLUSTER_VERSION: 60.4.2

--- a/template/vars/taskcluster_version_firefoxci.yaml
+++ b/template/vars/taskcluster_version_firefoxci.yaml
@@ -1,3 +1,3 @@
 # This defines the current Taskcluster version, the default version for worker-runner and workers.
 env_vars:
-  TASKCLUSTER_VERSION: 62.0.0
+  TASKCLUSTER_VERSION: 64.1.2


### PR DESCRIPTION
- 61: To pull in the d2g --privileged change (https://github.com/taskcluster/taskcluster/issues/6890) in the v61 TC release (https://github.com/taskcluster/taskcluster/releases/tag/v61.0.0).
- 64: Pull in fix (https://github.com/taskcluster/taskcluster/issues/6928).