### PR TITLE
Bump generic worker version for translations and firefoxci

### DIFF
--- a/template/vars/taskcluster_version_firefoxci.yaml
+++ b/template/vars/taskcluster_version_firefoxci.yaml
@@ -1,3 +1,3 @@
 # This defines the current Taskcluster version, the default version for worker-runner and workers.
 env_vars:
-  TASKCLUSTER_VERSION: 60.4.0
+  TASKCLUSTER_VERSION: 64.2.0

--- a/template/vars/taskcluster_version_translations.yaml
+++ b/template/vars/taskcluster_version_translations.yaml
@@ -1,3 +1,3 @@
 # This defines the current Taskcluster version, the default version for worker-runner and workers.
 env_vars:
-  TASKCLUSTER_VERSION: 60.4.0
+  TASKCLUSTER_VERSION: 64.2.0


### PR DESCRIPTION
This picks up:
- A fix that allows longer maxRunTimes for d2g tasks: https://github.com/taskcluster/taskcluster/pull/6932
- Improved GCP spot termination detection: https://github.com/taskcluster/taskcluster/pull/6925