### PR TITLE
Rename simple generic worker to insecure

### DIFF
--- a/scripts/generic-worker-linux/01-install-generic-worker.sh
+++ b/scripts/generic-worker-linux/01-install-generic-worker.sh
@@ -16,7 +16,7 @@ TASKCLUSTER_PROXY_VERSION='v5.1.0'
 # install generic-worker into /home/ubuntu/generic_worker
 mkdir -p /home/ubuntu/generic_worker
 cd /home/ubuntu/generic_worker
-retry curl -L "https://github.com/taskcluster/taskcluster/releases/download/v${GENERIC_WORKER_VERSION}/generic-worker-simple-linux-amd64" > generic-worker
+retry curl -L "https://github.com/taskcluster/taskcluster/releases/download/v${GENERIC_WORKER_VERSION}/generic-worker-insecure-linux-amd64" > generic-worker
 retry curl -L "https://github.com/taskcluster/livelog/releases/download/${LIVELOG_VERSION}/livelog-linux-amd64" > livelog
 retry curl -L "https://github.com/taskcluster/taskcluster-proxy/releases/download/${TASKCLUSTER_PROXY_VERSION}/taskcluster-proxy-linux-amd64" > taskcluster-proxy
 chmod a+x generic-worker taskcluster-proxy livelog


### PR DESCRIPTION
This got renamed in Taskcluster; currently 404s after #133