### PR TITLE
Bug 1859323 - set WorkingDirectory for generic-worker simple engine

### DIFF
--- a/scripts/worker-runner-gw-systemd/20-add-and-enable-systemd-service.sh
+++ b/scripts/worker-runner-gw-systemd/20-add-and-enable-systemd-service.sh
@@ -23,6 +23,7 @@ ExecStart=/usr/local/bin/start-worker /etc/start-worker.yml
 StandardOutput=syslog+console
 StandardError=syslog+console
 User=ubuntu
+WorkingDirectory=~
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
worker runner expects to run from a directory it can write to.

cc @petemoore 