### PR TITLE
Bump translations GPU workers to taskcluster 64.2.6

### DIFF
--- a/template/vars/taskcluster_version_translations.yaml
+++ b/template/vars/taskcluster_version_translations.yaml
@@ -1,3 +1,3 @@
 # This defines the current Taskcluster version, the default version for worker-runner and workers.
 env_vars:
-  TASKCLUSTER_VERSION: 64.2.0
+  TASKCLUSTER_VERSION: 64.2.6


### PR DESCRIPTION
This picks up some fixes that speed up artifact uploading, which we need to handle spot terminations properly:
* https://github.com/taskcluster/taskcluster/pull/6982
* https://github.com/taskcluster/taskcluster/pull/6977