### PR TITLE
Bump Firefox CI Taskcluster version to 64.2.6

### DIFF
--- a/template/vars/taskcluster_version_firefoxci.yaml
+++ b/template/vars/taskcluster_version_firefoxci.yaml
@@ -1,3 +1,3 @@
 # This defines the current Taskcluster version, the default version for worker-runner and workers.
 env_vars:
-  TASKCLUSTER_VERSION: 64.2.0
+  TASKCLUSTER_VERSION: 64.2.6


### PR DESCRIPTION
This version uploads artifacts in parallel after a spot termination, which increases the chance that we get them all uploaded prior to getting shut down.