### PR TITLE
sbom improvements

### DIFF
--- a/builders/monopacker-testing-image.yaml
+++ b/builders/monopacker-testing-image.yaml
@@ -1,4 +1,8 @@
 # a barebones image used for testing monopacker
+#
+# ideally clean up these images occasionally on gcp console
+#   https://console.cloud.google.com/compute/images?tab=images&project=taskcluster-imaging&pageState=(%22images%22:(%22f%22:%22%255B%257B_22k_22_3A_22name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22monopacker-testing_5C_22_22_2C_22i_22_3A_22name_22%257D%255D%22))
+#
 template: googlecompute
 platform: linux
 

--- a/monopacker/post-processors/move_sbom_to_latest_artifact_name.py
+++ b/monopacker/post-processors/move_sbom_to_latest_artifact_name.py
@@ -28,10 +28,11 @@ for build in data['builds']:
 
 # Handle the move operation or describe the action if in debug mode
 if matching_build:
+    name = matching_build['name']
     artifact_id = matching_build['artifact_id']
     source_path = 'SBOMs/temp_sbom.md'
     destination_dir = 'SBOMs'
-    destination_path = f'{destination_dir}/{artifact_id}.md'
+    destination_path = f'{destination_dir}/{name}/{artifact_id}.md'
     
     if not os.path.exists(source_path):
         print(f'File {source_path} not found.')
@@ -42,7 +43,7 @@ if matching_build:
     else:
         try:
             # Create the destination directory if it doesn't exist
-            os.makedirs(destination_dir, exist_ok=True)
+            os.makedirs(destination_path, exist_ok=True)
             # Move the file
             shutil.move(source_path, destination_path)
             print(f'Moved {source_path} to {destination_path}')

--- a/monopacker/post-processors/move_sbom_to_latest_artifact_name.py
+++ b/monopacker/post-processors/move_sbom_to_latest_artifact_name.py
@@ -31,8 +31,8 @@ if matching_build:
     name = matching_build['name']
     artifact_id = matching_build['artifact_id']
     source_path = 'SBOMs/temp_sbom.md'
-    destination_dir = 'SBOMs'
-    destination_path = f'{destination_dir}/{name}/{artifact_id}.md'
+    destination_dir = f'SBOMs/{name}'
+    destination_path = f'{destination_dir}/{artifact_id}.md'
     
     if not os.path.exists(source_path):
         print(f'File {source_path} not found.')
@@ -43,7 +43,7 @@ if matching_build:
     else:
         try:
             # Create the destination directory if it doesn't exist
-            os.makedirs(destination_path, exist_ok=True)
+            os.makedirs(destination_dir, exist_ok=True)
             # Move the file
             shutil.move(source_path, destination_path)
             print(f'Moved {source_path} to {destination_path}')


### PR DESCRIPTION
In preparation to commit these logs into version control, it seems advisable to place them in sub-directories (named after the builder).

before:

```
SBOMS
├── README.md
├── monopacker-testing-image-googlecompute-2024-07-18t00-06-09z.md
```

after:

```
SBOMS
├── README.md
├── gw-fxci-gcp-l1-gui
│   └── gw-fxci-gcp-l1-gui-googlecompute-2024-08-22t22-48-09z.md
├── monopacker-testing-image
│   ├── monopacker-testing-image-googlecompute-2024-07-25t21-56-46z.md
│   └── monopacker-testing-image-googlecompute-2024-09-17t21-28-49z.md
```