### PR TITLE
unlock keyring on login

### DIFF
--- a/scripts/ubuntu-jammy-from-community-gui/51-unlock-keyring.sh
+++ b/scripts/ubuntu-jammy-from-community-gui/51-unlock-keyring.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -exv
+
+# init helpers
+helpers_dir=${MONOPACKER_HELPERS_DIR:-"/etc/monopacker/scripts"}
+for h in ${helpers_dir}/*.sh; do
+    . $h;
+done
+
+echo "session optional        pam_gnome_keyring.so      use_authtok" >> /etc/pam.d/gdm-password
+echo "password        optional        pam_gnome_keyring.so" >> /etc/pam.d/passwd

--- a/scripts/ubuntu-jammy-from-community-gui/51-unlock-keyring.sh
+++ b/scripts/ubuntu-jammy-from-community-gui/51-unlock-keyring.sh
@@ -9,13 +9,14 @@ for h in ${helpers_dir}/*.sh; do
 done
 
 # rebuild keyring
-apt install curl pkg-config
-curl -o ~/gnome-keyring.tar.xz https://download.gnome.org/sources/gnome-keyring/46/gnome-keyring-46.2.tar.xz
-cd ~
+apt install -y curl pkg-config
+cd /tmp
+curl -o gnome-keyring.tar.xz https://download.gnome.org/sources/gnome-keyring/46/gnome-keyring-46.2.tar.xz
 tar xvf gnome-keyring.tar.xz
 ./configure --prefix=/usr --sysconfdir=/etc --enable-pam --with-pam-dir=/lib/x86_64-linux-gnu/security
 make
 make install
+cd -
 
 echo "session optional        pam_gnome_keyring.so      use_authtok" >> /etc/pam.d/gdm-password
 echo "password        optional        pam_gnome_keyring.so" >> /etc/pam.d/passwd

--- a/scripts/ubuntu-jammy-from-community-gui/51-unlock-keyring.sh
+++ b/scripts/ubuntu-jammy-from-community-gui/51-unlock-keyring.sh
@@ -9,13 +9,16 @@ for h in ${helpers_dir}/*.sh; do
 done
 
 # rebuild keyring
-apt install -y curl pkg-config
+sudo apt update
+sudo apt install -y build-essential libglib2.0-dev libgcrypt20-dev libpam0g-dev autoconf \
+  automake libtool pkg-config curl pkg-config libgcr-3-dev libgck-1-dev xsltproc
 cd /tmp
 curl -o gnome-keyring.tar.xz https://download.gnome.org/sources/gnome-keyring/46/gnome-keyring-46.2.tar.xz
 tar xvf gnome-keyring.tar.xz
 cd gnome-keyring-46.2
+export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
 ./configure --prefix=/usr --sysconfdir=/etc --enable-pam --with-pam-dir=/lib/x86_64-linux-gnu/security
-make
+make -j2
 make install
 cd ~
 

--- a/scripts/ubuntu-jammy-from-community-gui/51-unlock-keyring.sh
+++ b/scripts/ubuntu-jammy-from-community-gui/51-unlock-keyring.sh
@@ -13,10 +13,11 @@ apt install -y curl pkg-config
 cd /tmp
 curl -o gnome-keyring.tar.xz https://download.gnome.org/sources/gnome-keyring/46/gnome-keyring-46.2.tar.xz
 tar xvf gnome-keyring.tar.xz
+cd gnome-keyring-46.2
 ./configure --prefix=/usr --sysconfdir=/etc --enable-pam --with-pam-dir=/lib/x86_64-linux-gnu/security
 make
 make install
-cd -
+cd ~
 
 echo "session optional        pam_gnome_keyring.so      use_authtok" >> /etc/pam.d/gdm-password
 echo "password        optional        pam_gnome_keyring.so" >> /etc/pam.d/passwd

--- a/scripts/ubuntu-jammy-from-community-gui/51-unlock-keyring.sh
+++ b/scripts/ubuntu-jammy-from-community-gui/51-unlock-keyring.sh
@@ -17,7 +17,7 @@ curl -o gnome-keyring.tar.xz https://download.gnome.org/sources/gnome-keyring/46
 tar xvf gnome-keyring.tar.xz
 cd gnome-keyring-46.2
 export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
-./configure --prefix=/usr --sysconfdir=/etc --enable-pam --with-pam-dir=/lib/x86_64-linux-gnu/security
+./configure --prefix=/usr --sysconfdir=/etc --enable-pam --with-pam-dir=/lib/x86_64-linux-gnu/security --disable-doc
 make -j2
 make install
 cd ~

--- a/scripts/ubuntu-jammy-from-community-gui/51-unlock-keyring.sh
+++ b/scripts/ubuntu-jammy-from-community-gui/51-unlock-keyring.sh
@@ -8,5 +8,14 @@ for h in ${helpers_dir}/*.sh; do
     . $h;
 done
 
+# rebuild keyring
+apt install curl pkg-config
+curl -o ~/gnome-keyring.tar.xz https://download.gnome.org/sources/gnome-keyring/46/gnome-keyring-46.2.tar.xz
+cd ~
+tar xvf gnome-keyring.tar.xz
+./configure --prefix=/usr --sysconfdir=/etc --enable-pam --with-pam-dir=/lib/x86_64-linux-gnu/security
+make
+make install
+
 echo "session optional        pam_gnome_keyring.so      use_authtok" >> /etc/pam.d/gdm-password
 echo "password        optional        pam_gnome_keyring.so" >> /etc/pam.d/passwd

--- a/scripts/ubuntu-jammy-from-community-gui/70-additional-talos-reqs.sh
+++ b/scripts/ubuntu-jammy-from-community-gui/70-additional-talos-reqs.sh
@@ -33,14 +33,6 @@ pkg_name="linux-gcp-${short_version}-headers-${version_minus_dash_gcp}"
 sudo apt-get update
 sudo apt-get -y reinstall linux-headers-gcp linux-headers-`uname -r` ${pkg_name}
 
-# TODO: remove this once the bugs below are fixed
-#
-# issue: Kernel 6.8.0 removes strlcpy, but the canonical-shipped v4l2loopback module uses it still.
-#   see: https://bugs.launchpad.net/ubuntu/+source/v4l2loopback/+bug/2076951
-#        https://bugs.launchpad.net/ubuntu/+source/v4l2loopback/+bug/2078961
-#
-# remove 6.8.0 kernel packages for now
-sudo apt-get remove -y linux-image-6.8.0-1015-gcp linux-gcp-6.8-tools-6.8.0-1015 linux-gcp-6.8-headers-6.8.0-1015
 
 #
 # apt packages
@@ -55,7 +47,22 @@ apt-get install -y dkms kmod llvm sox libxcb1 nodejs xvfb apt-utils
 #
 # install v4l2loopback
 #
-apt-get install -y v4l2loopback-dkms v4l2loopback-utils
+# normal installation command
+# apt-get install -y v4l2loopback-dkms v4l2loopback-utils
+#
+# fixed installation command
+#   issue: Kernel 6.8.0 removes strlcpy, but the canonical-shipped v4l2loopback module uses it still.
+#     see: https://bugs.launchpad.net/ubuntu/+source/v4l2loopback/+bug/2076951
+#          https://bugs.launchpad.net/ubuntu/+source/v4l2loopback/+bug/2078961
+#
+# use fix from 2076951 (link above)
+cd /tmp
+wget http://ftp.us.debian.org/debian/pool/main/v/v4l2loopback/v4l2loopback-dkms_0.13.2-1_all.deb
+sudo dpkg -i v4l2loopback-dkms_0.13.2-1_all.deb
+rm /tmp/v4l2loopback-dkms*.deb
+cd -
+apt-get install -y v4l2loopback-utils
+
 # verify
 dkms status
 
@@ -65,7 +72,7 @@ dkms status
 #
 
 # required on 22.04?
-# 
+#
 # if [[ "$BUILD_V4L2LOOPBACK" ]]; then
 #     # This is for Ubuntu 18.04 in GCP. We have to build the module, otherwise it will not work.
 #     V4L2LOOPBACK_VERSION=${V4L2LOOPBACK_VERSION:-0.12.5}

--- a/template/vars/googlecompute_jammy.yaml
+++ b/template/vars/googlecompute_jammy.yaml
@@ -1,3 +1,6 @@
 ---
 ssh_username: ubuntu
-source_image_family: ubuntu-2204-lts
+# pin to make more deterministic
+# source_image_family: ubuntu-2204-lts
+#   - image found via `gcloud compute images list --show-deprecated | grep ubuntu-2204-lts`
+source_image: ubuntu-2204-jammy-v20240927


### PR DESCRIPTION
Attempting to force keyring to unlock on successful login auth, using [this document](https://wiki.gnome.org/Projects(2f)GnomeKeyring(2f)Pam.html) as instructions to modify pam.d configs. Because PAM now breaks gdm down into several subfiles, I chose to update `gdm-password` and `passwd`, I doubt `gnome-screensaver` will be relevant here.